### PR TITLE
include passenger_apache2::default rather than passenger_apache2::mod_rails

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ end
 
 include_recipe "apache2"
 include_recipe "apache2::mod_rewrite"
-include_recipe "passenger_apache2::mod_rails"
+include_recipe "passenger_apache2"
 include_recipe "mysql::server"
 include_recipe "git"
 


### PR DESCRIPTION
As it's now, `redmine::default` includes `passenger_apache2::mod_rails`, so the chef-client log goes:

```
Recipe: passenger_apache2::source
  * package[httpd-devel] action install (up to date)
  * package[libcurl-devel] action install (up to date)
  * package[openssl-devel] action install (up to date)
  * package[zlib-devel] action install (up to date)
  * gem_package[passenger] action install (up to date)
  * execute[passenger_module] action run (up to date)
Recipe: passenger_apache2::default
  * file[/etc/httpd/mods-available/passenger.load] action create (up to date)
  * execute[a2enmod passenger] action run (skipped due to not_if)
Recipe: passenger_apache2::mod_rails
  * template[/etc/httpd/mods-available/passenger.conf] action create (up to date)
```

`template[/etc/httpd/mods-available/passenger.conf]` is created _AFTER_ running `execute[a2enmod passenger]`, and `passenger.conf` will not be linked to `/etc/httpd/mods-enabled/passenger.conf`.

But if `redmine::default` includes `passenger_apache2::default`, the chef-client log will be:

```
Recipe: passenger_apache2::source
  * package[httpd-devel] action install (up to date)
  * package[libcurl-devel] action install (up to date)
  * package[openssl-devel] action install (up to date)
  * package[zlib-devel] action install (up to date)
  * gem_package[passenger] action install (up to date)
  * execute[passenger_module] action run (up to date)
Recipe: passenger_apache2::mod_rails
  * template[/etc/httpd/mods-available/passenger.conf] action create (up to date)
Recipe: passenger_apache2::default
  * file[/etc/httpd/mods-available/passenger.load] action create (up to date)
  * execute[a2enmod passenger] action run (skipped due to not_if)
```

`template[/etc/httpd/mods-available/passenger.conf]` will be created _BEFORE_ running `execute[a2enmod passenger]`, and `passenger.conf` will be linked to `/etc/httpd/mods-enabled/passenger.conf`.

Platform tested:
- CentOS 6.3 64bit Plain

Version tested:
- chef-solo 11.4.0
- http://community.opscode.com/cookbooks/apache2 1.6.0
- http://community.opscode.com/cookbooks/passenger_apache2 2.0.0
- https://github.com/juanje/cookbook-redmine 0.0.4
