### PR TITLE
Updates for usage of mysql2 gem and passenger_apache2 2.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,9 +19,15 @@ Vagrant.configure("2") do |config|
         }
       },
       :mysql => {
-        :server_root_password => "supersecret_password"
+        :server_root_password => "supersecret_password",
+        :server_debian_password => "supersecret_password",
+        :server_repl_password => "supersecret_password"
       }
     }
+  end
+
+  config.vm.provider :virtualbox do |vb|
+   vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default["redmine"]["deploy_to"] = '/opt/redmine'
 default["redmine"]["path"]      = '/var/www/redmine'
 
 # databases
-default["redmine"]["databases"]["production"]["adapter"]  = 'mysql'
+default["redmine"]["databases"]["production"]["adapter"]  = 'mysql2'
 default["redmine"]["databases"]["production"]["database"] = 'redmine'
 default["redmine"]["databases"]["production"]["username"] = 'redmine'
 default["redmine"]["databases"]["production"]["password"] = 'password'
@@ -26,7 +26,7 @@ when "redhat","centos","amazon","scientific","fedora","suse"
 when "debian","ubuntu"
   default["redmine"]["packages"] = {
     "mysql"   => %w{ libmysqlclient-dev },
-    "apache"  => %w{ apache2-prefork-dev libapr1-dev libaprutil1-dev libcurl4-openssl-dev },
+    "apache"  => %w{ apache2-prefork-dev libapr1-dev libaprutil1-dev },
     "rmagick" => %w{ libmagickcore-dev libmagickwand-dev librmagick-ruby },
     #TODO: SCM packages should be installed only if they are goin to be used
     #NOTE: git will be installed with a recipe because is needed for the deploy resource

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,11 +23,12 @@ when "redhat","centos","amazon","scientific","fedora","suse"
   include_recipe "yum::epel"
 when "debian","ubuntu"
   include_recipe "apt"
+  package "ruby1.9.1-full"
 end
 
 include_recipe "apache2"
 include_recipe "apache2::mod_rewrite"
-include_recipe "passenger_apache2::mod_rails"
+include_recipe "passenger_apache2"
 include_recipe "mysql::server"
 include_recipe "git"
 


### PR DESCRIPTION
Hello,

Thanks for your work on this cookbook.  Here are some changes I came up with to make the cookbook work on my system.
1. db:migrate was failing because database.yaml needed to use mysql2 rather than mysql.  This may have been due to a recent change in Redmine.
2. Apparently the usage of passenger_apache2 has changed.  The recipe to include is now simply "passenger_apache2", not "passenger_apache2::mod_rails"
3. I found that passenger_apache2 was being installed into the embedded Ruby installation.  Installing ruby explicitly first seemed to have fixed that.  There is still some issue as I found that the passenger.load file is generated incorrectly on the first chef run.  It points to the module in the embedded chef Ruby gems directory, even though it is installed in the system Ruby gems directory.  Running chef a second time corrects the path in passenger.load.  This appears to be an issue with passenger_apache2.  I have a ticket opened with Opscode about this.

I know that I raised an issue about item 3 above and, if I remember correctly, you were not able to reproduce it.  I expect the same is the case for 1 and 2 as well.  I am wondering if you may be using an older versions of dependent cookbooks?  Here is my Berksfile.lock.  Perhaps you could compare these versions against your Berksfile.lock?  

```
cookbook 'redmine', :path => '/home/btomasini/git/extchef/cookbook-redmine'
cookbook 'apt', :locked_version => '1.9.0'
cookbook 'yum', :locked_version => '2.2.0'
cookbook 'git', :locked_version => '2.3.0'
cookbook 'dmg', :locked_version => '1.1.0'
cookbook 'build-essential', :locked_version => '1.3.4'
cookbook 'windows', :locked_version => '1.8.4'
cookbook 'chef_handler', :locked_version => '1.1.4'
cookbook 'runit', :locked_version => '1.0.6'
cookbook 'apache2', :locked_version => '1.6.0'
cookbook 'passenger_apache2', :locked_version => '2.0.0'
cookbook 'mysql', :locked_version => '2.1.2'
cookbook 'openssl', :locked_version => '1.0.2'
```

Other items:
1. The mysql server install required some additional passwords to be specfiied, so I added them to the Vagrantfile.
2. I added a vm setting for "natdnshostresolver1" to make the virtual machine work on a Ubuntu 12.10 host.  Feel free to ignore this change.

Thanks,

Ben
