### PR TITLE
Set value of local variable "adapter" in recipes/source.rb to "mysql" if it equals "mysql2"

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -20,6 +20,9 @@
 # Some handy vars
 environment = node['redmine']['env']
 adapter = node["redmine"]["databases"][environment]["adapter"]
+if adapter == "mysql2"
+  adapter = "mysql"
+end
 
 #Setup system package manager
 case node['platform']


### PR DESCRIPTION
In some contexts the attribute node["redmine"]["databases"][environment]["adapter"] refers to a gem name.  As such it can assume value of "mysql" or "mysql2" among others.  However, in recipes/sources.rb the adapter variable is used repeatedly in case statements that do not support the value "mysql2".  

This is the error log received when node["redmine"]["databases"][environment]["adapter"] == "mysql2"

<pre>================================================================================

Recipe Compile Error in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/redmine/recipes/default.rb

================================================================================




NoMethodError

-------------

undefined method `each' for nil:NilClass




Cookbook Trace:

---------------

  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/redmine/recipes/source.rb:50:in `from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/redmine/recipes/default.rb:27:in `from_file'


Relevant File Content:
----------------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/redmine/recipes/source.rb:

 43:  if node['redmine']['install_rmagick']
 44:    node['redmine']['packages']['rmagick'].each do |pkg|
 45:      package pkg
 46:    end
 47:  end
 48:  
 49:  #Setup database
 50>> node['redmine']['packages'][adapter].each do |pkg|
 51:    package pkg
 52:  end
 53:  case adapter
 54:  when "mysql"
 55:    include_recipe "mysql::server"
 56:    include_recipe "database::mysql"
 57:  when "postgresql"
 58:    include_recipe "postgresql::server"
 59:    include_recipe "database::postgresql"



[2013-05-23T17:14:19+00:00] ERROR: Running exception handlers
[2013-05-23T17:14:19+00:00] ERROR: Exception handlers complete
[2013-05-23T17:14:19+00:00] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[2013-05-23T17:14:19+00:00] FATAL: NoMethodError: undefined method `each' for nil:NilClass
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
</pre>


Rewriting the value of adapter from "mysql2" to "mysql" within recipes/sources.rb allows the existing case statements to select mysql components.

Platform tested: Debian 7 RC1 64-bit
Version tested: Chef: 11.4.0
Cookbook versions:
- apache2 (1.6.2)
- apt (1.9.2)
- aws (0.101.0)
- build-essential (1.4.0)
- chef_handler (1.1.4)
- database (1.3.12)
- dmg (1.1.0)
- git (2.5.0)
- gitolite (0.1.0)
- mysql (3.0.0)
- openssl (1.0.2)
- passenger_apache2 (2.0.0)
- perl (1.1.0)
- postgresql (3.0.0)
- redmine (0.1.0)
- runit (1.1.4)
- windows (1.8.10)
- xfs (1.1.0)
- yum (2.2.2)
